### PR TITLE
chore(deps): bump antelope interface dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
     }
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.2",
-    "@antelopejs/interface-redis": "^0.0.2",
-    "@antelopejs/interface-stripe": "^0.0.2",
+    "@antelopejs/interface-api": "^0.0.5",
+    "@antelopejs/interface-core": "^0.0.5",
+    "@antelopejs/interface-redis": "^0.0.6",
+    "@antelopejs/interface-stripe": "^0.0.4",
     "ioredis": "^5.10.1",
     "stripe": "^18.5.0",
     "uuid": "11.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,17 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-core@0.0.5)
+      '@antelopejs/interface-core':
+        specifier: ^0.0.5
+        version: 0.0.5
       '@antelopejs/interface-redis':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.6
+        version: 0.0.6(@antelopejs/interface-core@0.0.5)
       '@antelopejs/interface-stripe':
-        specifier: ^0.0.2
-        version: 0.0.2(@types/node@22.19.15)
+        specifier: ^0.0.4
+        version: 0.0.4(@antelopejs/interface-core@0.0.5)(@types/node@22.19.15)
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
@@ -51,17 +54,23 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-api@0.0.2':
-    resolution: {integrity: sha512-wD9kODuc5cns8mCVv4hLL3N8eF2iXtXoMgtDS7zJ3hZZoPnlpxZ7mDP4fMRUDBl0pm9ZTPKb5abzu3BZg6T/EA==}
+  '@antelopejs/interface-api@0.0.5':
+    resolution: {integrity: sha512-BApviHE1vVkORDWtC8x8N2xCxBdFZZnhgMlxDuUmlXz2fGlYqBX1inIQQrEyOY31Zc/WN7nJpcA0zjjwk7Sp9A==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-core@0.0.2':
-    resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+  '@antelopejs/interface-core@0.0.5':
+    resolution: {integrity: sha512-4H6hpFfiK2+DE8vL2mEtPbq1WNch9lt40QNr9KjBrOAtnuq/zMfIlzhbEsda39m+FVkMWXfUYoVolRogVKCLIQ==}
 
-  '@antelopejs/interface-redis@0.0.2':
-    resolution: {integrity: sha512-BT4wtDG/xVqCrExcJUnMjBJRJdF2+t4GqkYB8r6vxU49hlZYW3cg8JBt7WL2n04ggBFi6znQg/B2YlVcZR+yuA==}
+  '@antelopejs/interface-redis@0.0.6':
+    resolution: {integrity: sha512-c9at7pIFO2UbFlL4EFJht8Wt8uir33oj1Ja1rxMgPLPO8x8bOk4s9//Bqaigrjc0ELj/5zZQkqx3fHdmNru5QQ==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
-  '@antelopejs/interface-stripe@0.0.2':
-    resolution: {integrity: sha512-uTPye9NLnfKVMZ/BurM0SSRS3J3p5bbf/CYtEpLdjhbZHRu3xp72bmPymQ+hnAiWRSDixUocgZeG3Mrn2dTang==}
+  '@antelopejs/interface-stripe@0.0.4':
+    resolution: {integrity: sha512-EVdVX+AgBvUCg7wlK/Y4lJ87v98Z/+CS2OJmbCiq65Sw9GMzszRs1LXpLXgKsHPHROqNk58QIOk8bMPdcXS85g==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -1246,24 +1255,24 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-api@0.0.2':
+  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.2
+      '@antelopejs/interface-core': 0.0.5
 
-  '@antelopejs/interface-core@0.0.2':
+  '@antelopejs/interface-core@0.0.5':
     dependencies:
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-redis@0.0.2':
+  '@antelopejs/interface-redis@0.0.6(@antelopejs/interface-core@0.0.5)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.2
+      '@antelopejs/interface-core': 0.0.5
       ioredis: 5.10.1
     transitivePeerDependencies:
       - supports-color
 
-  '@antelopejs/interface-stripe@0.0.2(@types/node@22.19.15)':
+  '@antelopejs/interface-stripe@0.0.4(@antelopejs/interface-core@0.0.5)(@types/node@22.19.15)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.2
+      '@antelopejs/interface-core': 0.0.5
       stripe: 18.5.0(@types/node@22.19.15)
     transitivePeerDependencies:
       - '@types/node'


### PR DESCRIPTION
Bump `@antelopejs/interface-*` (and playground/config) to latest published versions. Interfaces stay in `dependencies`. Verified: install, build, lint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps three `@antelopejs/interface-*` packages to their latest versions and adds `@antelopejs/interface-core` as an explicit direct dependency to satisfy the peer dependency constraints introduced by those newer releases.

- `@antelopejs/interface-api` `0.0.2 → 0.0.5`, `@antelopejs/interface-redis` `0.0.2 → 0.0.6`, and `@antelopejs/interface-stripe` `0.0.2 → 0.0.4` are all updated; each now declares a peer on `@antelopejs/interface-core@>=0.0.3 <1.0.0`.
- `@antelopejs/interface-core@^0.0.5` is added as a direct dependency and resolves to `0.0.5` in the lockfile, satisfying the peer constraint across all three packages (resolving the previously flagged `0.0.2` mismatch).

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three bumped packages now resolve against an `@antelopejs/interface-core` version that satisfies their declared peer constraints, and the previously flagged mismatch is fully resolved.

The change is a straightforward dependency bump: three interface packages are updated to their latest versions, and `@antelopejs/interface-core` is added explicitly to fix the peer dependency resolution. The lockfile confirms all four packages resolve to `@antelopejs/interface-core@0.0.5`, which satisfies `>=0.0.3 <1.0.0` across the board. No source code was changed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Bumps three `@antelopejs/interface-*` packages to their latest versions and adds `@antelopejs/interface-core@^0.0.5` as an explicit direct dependency to satisfy the new peer dependency constraints. |
| pnpm-lock.yaml | Lockfile updated to resolve all three bumped packages against `@antelopejs/interface-core@0.0.5`, which satisfies the `>=0.0.3 <1.0.0` peer constraint declared by the new versions. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json"] -->|"direct dep ^0.0.5"| B["@antelopejs/interface-core@0.0.5"]
    A -->|"^0.0.5"| C["@antelopejs/interface-api@0.0.5"]
    A -->|"^0.0.6"| D["@antelopejs/interface-redis@0.0.6"]
    A -->|"^0.0.4"| E["@antelopejs/interface-stripe@0.0.4"]
    C -->|"peerDep >=0.0.3 <1.0.0 ✅"| B
    D -->|"peerDep >=0.0.3 <1.0.0 ✅"| B
    E -->|"peerDep >=0.0.3 <1.0.0 ✅"| B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["package.json"] -->|"direct dep ^0.0.5"| B["@antelopejs/interface-core@0.0.5"]
    A -->|"^0.0.5"| C["@antelopejs/interface-api@0.0.5"]
    A -->|"^0.0.6"| D["@antelopejs/interface-redis@0.0.6"]
    A -->|"^0.0.4"| E["@antelopejs/interface-stripe@0.0.4"]
    C -->|"peerDep >=0.0.3 <1.0.0 ✅"| B
    D -->|"peerDep >=0.0.3 <1.0.0 ✅"| B
    E -->|"peerDep >=0.0.3 <1.0.0 ✅"| B
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(deps): bump antelope interface dep..."](https://github.com/antelopejs/stripe/commit/d0b0c207c4e318c0bea783b968e763222f13cb0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37904903)</sub>

<!-- /greptile_comment -->